### PR TITLE
Migrate to mlytools 0.8.4 (CSV > JSON descs), handle opk metadata in IML

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ Mais les images récupérées ne sont pas bien crées et ne sont pas, dans leur 
 
 Le script :
 1. lit le fichier IML d'une campagne d'acquisition
-2. en dérive un fichier CSV avec les attributs utiles : image, time, x, y, z, h
-3. modifie les métadonnées EXIF des images pour injecter les données de localisation afn de les rendre 360°
-4. appelle les *mapillary tools* pour prétraiter les images (supression des images trop proches, par exemple)
-5. téléverse vers l'API de Mapillary
+2. en dérive un fichier Mapillary JSON avec les attributs utiles
+3. téléverse vers l'API de Mapillary
 
 
 ## Prérequis
@@ -72,7 +70,7 @@ Activer une session virtuelle Python : `source ./venv/Scripts/activate`
 Afficher l'aide
 
 	process_sequence.py -h
-	
+
 	usage: process_sequence.py [-h] [--skip-preprocess] [--skip-exif]
 							   [--skip-upload]
 							   DATE PATH MAPILLARY_USER
@@ -87,7 +85,6 @@ Afficher l'aide
 	optional arguments:
 	  -h, --help         show this help message and exit
 	  --skip-preprocess  don't run preprocessing of pictures
-	  --skip-exif        don't write updated EXIF metadata in pictures
 	  --skip-upload      don't run upload of pictures
 
 
@@ -98,26 +95,19 @@ Conseil : utiliser la touche tabulation pour naviguer dans le système de fichie
 
 
 Exemple de chemin python : `/h/3_Photos/2017-10-04\ -\ RENNES\ -\ Corps_Nuds0410/`
-	
+
 
 
 
 ### Juste analyser et traiter le fichier IML
 
-	
-	python process_sequence.py --skip-exif --skip-upload 2018-02-16 /chemin_absolu_vers\ le\ repertoire/ sig_rm
-	
 
+	python process_sequence.py --skip-upload 2018-02-16 /chemin_absolu_vers\ le\ repertoire/ sig_rm
 
-### Juste patcher les métadonnées EXIF des photos : pas de preprocess ni d'upload
-
-	python mapillary_rm/process_sequence.py --skip-preprocess --skip-upload 2018-02-16 /chemin_absolu_vers\ le\ repertoire/ sig_rm sig_rm
-	
-	
 
 ### Juste l'upload
 
-	python process_sequence.py --skip-preprocess --skip-exif 2018-02-16 /chemin_absolu_vers\ le\ repertoire/ sig_rm sig_rm
+	python process_sequence.py --skip-preprocess 2018-02-16 /chemin_absolu_vers\ le\ repertoire/ sig_rm sig_rm
 
 
 ### La totale
@@ -137,7 +127,7 @@ Exemple :
 	Reading IML file line 3/438103 (0%)
 	Start date read from IML : 2024-07-16T11:03:11.356000
 	Do you want to use your date instead (2018-02-16) ? (y/n) y
-	Set the capture start time (in HH:MM format) : 09:00   
+	Set the capture start time (in HH:MM format) : 09:00
 
 
 
@@ -149,6 +139,6 @@ menu Edition > métadonnées > Ouvrir la position GPS dans geohack
 
 ## Notes
 
-Pour la partie GDAL on utilise le .whl de ce site 
+Pour la partie GDAL on utilise le .whl de ce site
 https://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal
 

--- a/process_sequence.py
+++ b/process_sequence.py
@@ -8,7 +8,7 @@
 
 # Libraries imports
 import argparse
-import csv
+import json
 import datetime
 import time
 import sys
@@ -16,15 +16,8 @@ import re
 from os import listdir, rename, mkdir
 from os.path import isfile, isdir, join, exists
 from PIL import Image
-from mapillary_tools.process_csv import process_csv
-from mapillary_tools.process_user_properties import process_user_properties
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
-from mapillary_tools.process_geotag_properties import process_geotag_properties
-from mapillary_tools.process_sequence_properties import process_sequence_properties
-from mapillary_tools.process_upload_params import process_upload_params
-from mapillary_tools.insert_MAPJson import insert_MAPJson
-from mapillary_tools.upload import upload
-from mapillary_tools.post_process import post_process
+from mapillary_tools import authenticate
+from mapillary_tools.commands.upload import Command as UploadCommand
 from osgeo import ogr
 from osgeo import osr
 
@@ -40,7 +33,6 @@ parser.add_argument('date', metavar='DATE', type=lambda s: datetime.datetime.str
 parser.add_argument('folder', metavar='PATH', type=str, help='path to access one sequence files (IML + JPG)')
 parser.add_argument('username', metavar='MAPILLARY_USER', type=str, help='Mapillary user name')
 parser.add_argument('--skip-preprocess', help='don\'t run preprocessing of pictures', action="store_true", dest='nopreprocess')
-parser.add_argument('--skip-exif', help='don\'t write updated EXIF metadata in pictures', action="store_true", dest='noexif')
 parser.add_argument('--skip-upload', help='don\'t run upload of pictures', action="store_true", dest='noupload')
 args = parser.parse_args()
 
@@ -60,6 +52,10 @@ def getIsoString(gpsTime):
 def getFixedIsoString(gpsTime, zeroTime, startEpoch):
 	gpsDate = datetime.datetime.fromtimestamp(startEpoch + gpsTime - zeroTime)
 	return gpsDate.isoformat() + ".000000" if gpsDate.microsecond == 0 else gpsDate.isoformat()
+
+# Function to transform ISO String into Mapillary date format
+def getMapillaryDateString(isoDateString):
+	return isoDateString.replace("-", "_").replace("T", "_").replace(":", "_").replace(".", "_")
 
 # Function to convert x/y into lon/lat
 InSR = osr.SpatialReference()
@@ -168,7 +164,7 @@ if not args.nopreprocess:
 			# Image entry separates every file metadata
 			# So we store previous metadata in global object
 			if currentMetadata is not None:
-				picturesMetadata[currentMetadata["image"]] = currentMetadata
+				picturesMetadata[currentMetadata["filename"]] = currentMetadata
 
 			# Check image exist in folder
 			image = re.sub('_\d{1,2}_', '_', value) # Change name format
@@ -176,7 +172,7 @@ if not args.nopreprocess:
 			# If exists, create empty metadata to store next picture info
 			if image in filesJpg:
 				currentMetadata = dict()
-				currentMetadata["image"] = image
+				currentMetadata["filename"] = join(args.folder, image)
 			# If not, create void metadata to skip processing
 			else:
 				currentMetadata = None
@@ -185,12 +181,12 @@ if not args.nopreprocess:
 		# Check other keys if current image exists in JPG files
 		elif currentMetadata is not None:
 			if key == "Time":
-				currentMetadata["time"] = getIsoString(float(value)) if not fixStartDate else getFixedIsoString(float(value), fixedStartDelta, fixedStartDate)
+				currentMetadata["MAPCaptureTime"] = getMapillaryDateString(getIsoString(float(value)) if not fixStartDate else getFixedIsoString(float(value), fixedStartDelta, fixedStartDate))
 
 				# Ask user for potential start date change if necessary
 				if not askedForDate:
 					askedForDate = True
-					print("\nStart date read from IML : %s" % currentMetadata["time"])
+					print("\nStart date read from IML : %s" % currentMetadata["MAPCaptureTime"])
 					askChangeDate = None
 					while askChangeDate != "y" and askChangeDate != "n":
 						askChangeDate = input("Do you want to use your date instead (%s) ? (y/n) " % args.date.date())
@@ -210,55 +206,46 @@ if not args.nopreprocess:
 				coords = value.split(" ")
 				ptx = projectCoordinates(coords[0], coords[1])
 				# X/Y are inverted in IML file
-				currentMetadata["y"] = ptx.GetX()
-				currentMetadata["x"] = ptx.GetY()
-				currentMetadata["z"] = coords[2]
+				currentMetadata["MAPLatitude"] = ptx.GetX()
+				currentMetadata["MAPLongitude"] = ptx.GetY()
+				currentMetadata["MAPAltitude"] = float(coords[2])
 
 			# HRP = heading/roll/pitch
 			elif key == "Hrp":
 				hrp = value.split(" ")
-				currentMetadata["h"] = hrp[0]
+				currentMetadata["MAPCompassHeading"] = { "TrueHeading": float(hrp[0]), "MagneticHeading": float(hrp[0]) }
 				#currentMetadata["r"] = hrp[1] # Not used by Mapillary script
 				#currentMetadata["p"] = hrp[2] # Not used by Mapillary script
 
-	# Write metadata as CSV
-	csvpath = join(args.folder, "0_mapillary.csv")
-	with open(csvpath, 'w', newline='') as csvfile:
-		# CSV header
-		# They should have same naming as in currentMetadata
-		fieldnames = ['image', 'time', 'x', 'y', 'z', 'h']
-		writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-		writer.writeheader()
+			# OPK = Omega/phi/kappa (alternative version of HRP)
+			elif key == "Opk":
+				opk = value.split(" ")
+				# ~ currentMetadata["p"] = opk[0] # Pitch, not used by Mapillary script
+				# ~ currentMetadata["r"] = opk[1] # Roll, not used by Mapillary script
+				currentMetadata["MAPCompassHeading"] = { "TrueHeading": float(opk[2]), "MagneticHeading": float(opk[2]) }
 
-		# CSV data
-		for pic in picturesMetadata.values():
-			if len(pic) > 0:
-				writer.writerow(pic)
+	# Write metadata as JSON
+	jsonpath = join(args.folder, "mapillary_image_description.json")
+	descs = list(picturesMetadata.values())
+	with open(jsonpath, "w") as jsonfile:
+		jsonfile.write(json.dumps(descs, indent=2))
 
-	# Print CSV processing results
+	# Print JSON processing results
 	print("")
 	if skipCount > 0:
 		print("Skipped %d images listed in IML but not in path" % skipCount)
-	print("Metadata written in %s" % csvpath)
-
-	# Call Mapillary CSV processor
-	if not args.noexif:
-		process_csv(folderPictures, csvpath, filename_column=1, timestamp_column=2, longitude_column=3, latitude_column=4, heading_column=6, altitude_column=5, time_format="%Y-%m-%dT%H:%M:%S.%f", header=True)
-	else:
-		print("Pictures EXIF metadata update is skipped")
+	print("Metadata written in %s" % jsonpath)
 else:
 	print("Pictures pre-processing is skipped")
 
 
 # Call Mapillary commands for upload
 if not args.noupload:
-	process_user_properties(folderPictures, args.username, verbose=True, rerun=True, skip_subfolders=True)
-	process_import_meta_properties(folderPictures, verbose=True, rerun=True, skip_subfolders=True)
-	process_geotag_properties(folderPictures, verbose=True, rerun=True, skip_subfolders=True)
-	process_sequence_properties(folderPictures, cutoff_distance=100, cutoff_time=300, duplicate_distance=2, duplicate_angle=10, verbose=True, rerun=True, skip_subfolders=True)
-	process_upload_params(folderPictures, args.username, verbose=True, rerun=True, skip_subfolders=True)
-	insert_MAPJson(folderPictures, verbose=True, rerun=True, skip_subfolders=True)
-	upload(folderPictures, number_threads=4, max_attempts=4, skip_subfolders=True)
-	post_process(folderPictures, verbose=True, skip_subfolders=True)
+	# ~ user_items = authenticate.authenticate_user(args.username)
+	UploadCommand().run({
+		"--user_name": args.username,
+		"import_path": args.folder,
+		# ~ "--dry_run": True
+	})
 else:
 	print("Pictures upload is skipped")

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,5 +1,5 @@
-git+https://github.com/mapillary/Piexif
 git+https://github.com/mapillary/mapillary_tools
 argparse
 datetime
 Pillow
+GDAL==3.*


### PR DESCRIPTION
@MaelREBOUX à priori les modifications apportées dans cette version suffisent à corriger les deux problèmes rencontrés :

- La balise "Opk" dans les fichiers IML est désormais interprétée
- Comme j'ai réinstallé mon OS, j'ai réinstallé les scripts Mapillary en l'état d'aujourd'hui. Ils ont supprimé la commande process_csv, maintenant il faut fournir un fichier JSON à la commande d'upload. Ça enlève la possibilité de simplement surcharger les balises EXIF des images de départ. J'ai donc implémenté l'écriture de ce JSON

Je te laisse tester à partir de cette branche et fusionner sur la branche principale si c'est OK de ton côté ? Je reste dispo s'il y a des soucis évidemment :wink: 